### PR TITLE
CASMPET-6997 Fix rebuilds for cray-node-discovery:1.2.4

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -39,7 +39,7 @@ pytest==4.6.9
 pytest-cov==2.8.1
 python-dateutil==2.7.5
 python-mimeparse==1.6.0
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.23.0
 requests-oauthlib==1.0.0
 responses==0.10.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
---index-url https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
---trusted-host arti.dev.cray.com
+--index-url https://arti.hpc.amslabs.hpecorp.net/artifactory/api/pypi/pypi-remote/simple
+--trusted-host arti.hpc.amslabs.hpecorp.net
 -c constraints.txt
 
 kubernetes


### PR DESCRIPTION
## Summary and Scope

Fix rebuild for `artifactory.algol60.net/csm-docker/stable/cray-node-discovery:1.2.4` image, which was broken due to deprecation of `arti.dev.cray.com`.

## Issues and Related PRs

* Resolves [CASMPET-6997](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6997)

## Testing
### Tested on:

  * Local development environment
  * Github

### Test description:

Image builds successfully.

## Risks and Mitigations

There's no change in resulting image, except for the version of PyYAML, which goes from 5.4.x to 6.0.x. PyYAML is not used directly by scripts on this image, it's a transitive dependency.
